### PR TITLE
Explicitly enable case-fold-search

### DIFF
--- a/orgtbl-aggregate.el
+++ b/orgtbl-aggregate.el
@@ -141,11 +141,12 @@ An horizontal line is translated as the special symbol `hline'."
   (let (buffer loc)
     (save-excursion
       (goto-char (point-min))
-      (if (re-search-forward
-	   (concat "^[ \t]*#\\+\\(tbl\\)?name:[ \t]*"
-		   (regexp-quote name-or-id)
-		   "[ \t]*$")
-	   nil t)
+      (if (let ((case-fold-search t))
+	    (re-search-forward
+	     (concat "^[ \t]*#\\+\\(tbl\\)?name:[ \t]*"
+		     (regexp-quote name-or-id)
+		     "[ \t]*$")
+	     nil t))
 	  (setq buffer (current-buffer)
 		loc (match-beginning 0))
 	(let ((id-loc (org-id-find name-or-id 'marker)))


### PR DESCRIPTION
I have been running with `(setq case-fold-search nil)` lately.  I noticed today that I wasn't able to use an aggregate dblock referring to a table with `#+NAME: foo` in upper case, which I *think* is allowed in org.  This commit turns `case-fold-search` on for the smallest possible scope.

Thanks for this package!  It's extremely useful.