### PR TITLE
Parse durations with different hour formats

### DIFF
--- a/orgtbl-aggregate.el
+++ b/orgtbl-aggregate.el
@@ -766,7 +766,7 @@ a hash-table, whereas GROUPS is a Lisp list."
    ;; Convert a duration into a number of seconds
    ((string-match
      (rx bos
-	 (group (any "0-9") (any "0-9"))
+	 (group (one-or-more (any "0-9")))
 	 ":"
 	 (group (any "0-9") (any "0-9"))
 	 (? ":" (group (any "0-9") (any "0-9")))

--- a/unittests.org
+++ b/unittests.org
@@ -467,6 +467,15 @@ Some (limited) handling of dates is available.
 |    13:55 |
 |    17:12 |
 
+#+name: some_durations_in_different_formats
+|      dur |
+|----------|
+| 01:30:01 |
+|  1:30:02 |
+|    01:30 |
+|     1:30 |
+|   100:30 |
+
 ** Aggregated table
 
 Test T, U, t formatters
@@ -476,6 +485,12 @@ Test T, U, t formatters
 |------------+------------+------------+------------|
 |      46650 |   12:57:30 |      12.96 |      12:57 |
 #+END:
+
+#+BEGIN: aggregate :table "some_durations_in_different_formats" :cols "vsum(dur);T"
+| vsum(dur) |
+|-----------|
+| 106:30:03 |
+#+END
 
 * Test durations HH@ MM' SS" style
 


### PR DESCRIPTION
org-mode allows hours in durations with and without leading zeros, and with more than two digits. Previously, orgtbl-aggregate only accepted entries with exactly two digits for the hour, e.g. "01:30" or "01:30:00".

The change in this PR is the least effort solution, and works for my purposes.

Theoretically it would be nice to use functionality built into org-mode to parse durations. I tried this inside `orgtbl-aggregate--read-calc-expr`:

```elisp
((string-match org-duration--h:mm-re expr)
    (* 60 (org-duration-to-minutes expr)))
```

however this only works when it returns an integer. Trying to convert it to the expected calc datatype, the best I could come up with was:

```elisp
((string-match org-duration--h:mm-re expr)
    (math-read-number-simple (number-to-string (* 60 (org-duration-to-minutes expr)))))
```

Obviously it's silly to convert with a roundtrip through string but I didn't find a better way, so I left it at that.